### PR TITLE
Remove info in README

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,5 +1,7 @@
 Copyright 2014-2015, Board of Trustees of Michigan State University
-          2016-2024, The Trustees of Columbia University in the City of New York.
+
+Copyright 2016-2024, The Trustees of Columbia University in the City of New York.
+
 All rights reserved.
 
 If you use this program to do productive scientific research that

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,5 +1,3 @@
-BSD 3-Clause License
-
 Copyright 2014-2015, Board of Trustees of Michigan State University
           2016-2024, The Trustees of Columbia University in the City of New York.
 All rights reserved.

--- a/LICENSE_PDFgui.rst
+++ b/LICENSE_PDFgui.rst
@@ -1,5 +1,7 @@
 Copyright 2006-2007, Board of Trustees of Michigan State University
-          2008-2024, The Trustees of Columbia University in the City of New York.
+
+Copyright 2008-2024, The Trustees of Columbia University in the City of New York.
+
 All rights reserved.
 
 SrMise incorporates source code from diffpy.pdfgui in the file

--- a/LICENSE_PDFgui.rst
+++ b/LICENSE_PDFgui.rst
@@ -1,5 +1,3 @@
-BSD 3-Clause License
-
 Copyright 2006-2007, Board of Trustees of Michigan State University
           2008-2024, The Trustees of Columbia University in the City of New York.
 All rights reserved.


### PR DESCRIPTION
I think Line 1 was added during the cookiecutting process but wasn't provided earlier:

https://github.com/diffpy/diffpy.srmise/blob/0200e4909d62d9681c8ff7e605a50a1fc3ec87a9/LICENSE.txt
