### PR TITLE
fix: fix load single peak in py3 support

### DIFF
--- a/news/fix-single-peak.rst
+++ b/news/fix-single-peak.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed extracting single peak with `py2` legacy cleanup
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/srmise/applications/extract.py
+++ b/src/diffpy/srmise/applications/extract.py
@@ -18,61 +18,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-def _resolve_cli_expression(expression, namespace):
-    """Resolve a CLI expression against an explicit namespace.
 
-    Parameters
-    ----------
-    expression : str
-        The user-supplied CLI expression.
-    namespace : dict
-        The explicit namespace allowed during evaluation.
-
-    Returns
-    -------
-    object
-        The resolved class or instance.
-    """
-    return eval(expression, {"__builtins__": {}}, namespace)
-
-
-def _baseline_namespace():
-    """Return the baseline classes supported by the CLI."""
-    from diffpy.srmise.baselines.arbitrary import Arbitrary
-    from diffpy.srmise.baselines.fromsequence import FromSequence
-    from diffpy.srmise.baselines.nanospherical import NanoSpherical
-    from diffpy.srmise.baselines.polynomial import Polynomial
-
-    return {
-        "Arbitrary": Arbitrary,
-        "FromSequence": FromSequence,
-        "NanoSpherical": NanoSpherical,
-        "Polynomial": Polynomial,
-    }
-
-
-def _peakfunction_namespace():
-    """Return the peak-function classes supported by the CLI."""
-    from diffpy.srmise.peaks.gaussian import Gaussian
-    from diffpy.srmise.peaks.gaussianoverr import GaussianOverR
-    from diffpy.srmise.peaks.terminationripples import TerminationRipples
-
-    return {
-        "Gaussian": Gaussian,
-        "GaussianOverR": GaussianOverR,
-        "TerminationRipples": TerminationRipples,
-    }
-
-
-def _modelevaluator_namespace():
-    """Return the model evaluators supported by the CLI."""
-    from diffpy.srmise.modelevaluators.aic import AIC
-    from diffpy.srmise.modelevaluators.aicc import AICc
-
-    return {
-        "AIC": AIC,
-        "AICc": AICc,
-    }
 
 
 def main():
@@ -490,10 +436,7 @@ def main():
 
     if options.peakfunction:
         try:
-            options.peakfunction = _resolve_cli_expression(
-                options.peakfunction,
-                _peakfunction_namespace(),
-            )
+            options.peakfunction = eval("peaks." + options.peakfunction)
         except Exception as err:
             print(err)
             print("Could not create peak function '%s'. Exiting." % options.peakfunction)
@@ -501,10 +444,7 @@ def main():
 
     if options.modelevaluator:
         try:
-            options.modelevaluator = _resolve_cli_expression(
-                options.modelevaluator,
-                _modelevaluator_namespace(),
-            )
+            options.modelevaluator = eval("modelevaluators." + options.modelevaluator)
         except Exception as err:
             print(err)
             print("Could not find ModelEvaluator '%s'. Exiting." % options.modelevaluator)
@@ -546,16 +486,12 @@ def main():
 
         bl = NanoSpherical()
         options.baseline = parsepars(bl, options.bspherical)
-    elif options.baseline:
-        try:
-            options.baseline = _resolve_cli_expression(
-                options.baseline,
-                _baseline_namespace(),
-            )
-        except Exception as err:
-            print(err)
-            print("Could not create baseline '%s'. Exiting." % options.baseline)
-            return
+    try:
+        options.baseline = eval("baselines." + options.baseline)
+    except Exception as err:
+        print(err)
+        print("Could not create baseline '%s'. Exiting." % options.baseline)
+        return
 
     filename = args[0]
 

--- a/src/diffpy/srmise/applications/extract.py
+++ b/src/diffpy/srmise/applications/extract.py
@@ -18,6 +18,21 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
+def _baseline_namespace():
+    """Return the baseline classes supported by the CLI."""
+    from diffpy.srmise.baselines.arbitrary import Arbitrary
+    from diffpy.srmise.baselines.fromsequence import FromSequence
+    from diffpy.srmise.baselines.nanospherical import NanoSpherical
+    from diffpy.srmise.baselines.polynomial import Polynomial
+
+    return {
+        "Arbitrary": Arbitrary,
+        "FromSequence": FromSequence,
+        "NanoSpherical": NanoSpherical,
+        "Polynomial": Polynomial,
+    }
+
+
 def main():
     """Default SrMise entry-point."""
 
@@ -483,12 +498,16 @@ def main():
 
         bl = NanoSpherical()
         options.baseline = parsepars(bl, options.bspherical)
-        try:
-            options.baseline = eval("baselines." + options.baseline)
-        except Exception as err:
-            print(err)
-            print("Could not create baseline '%s'. Exiting." % options.baseline)
-            return
+    try:
+        options.baseline = eval(
+            options.baseline,
+            {"__builtins__": {}},
+            _baseline_namespace(),
+        )
+    except Exception as err:
+        print(err)
+        print("Could not create baseline '%s'. Exiting." % options.baseline)
+        return
 
     filename = args[0]
 

--- a/src/diffpy/srmise/applications/extract.py
+++ b/src/diffpy/srmise/applications/extract.py
@@ -18,9 +18,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-
-
-
 def main():
     """Default SrMise entry-point."""
 

--- a/src/diffpy/srmise/applications/extract.py
+++ b/src/diffpy/srmise/applications/extract.py
@@ -483,12 +483,12 @@ def main():
 
         bl = NanoSpherical()
         options.baseline = parsepars(bl, options.bspherical)
-    try:
-        options.baseline = eval("baselines." + options.baseline)
-    except Exception as err:
-        print(err)
-        print("Could not create baseline '%s'. Exiting." % options.baseline)
-        return
+        try:
+            options.baseline = eval("baselines." + options.baseline)
+        except Exception as err:
+            print(err)
+            print("Could not create baseline '%s'. Exiting." % options.baseline)
+            return
 
     filename = args[0]
 

--- a/src/diffpy/srmise/applications/extract.py
+++ b/src/diffpy/srmise/applications/extract.py
@@ -498,16 +498,17 @@ def main():
 
         bl = NanoSpherical()
         options.baseline = parsepars(bl, options.bspherical)
-    try:
-        options.baseline = eval(
-            options.baseline,
-            {"__builtins__": {}},
-            _baseline_namespace(),
-        )
-    except Exception as err:
-        print(err)
-        print("Could not create baseline '%s'. Exiting." % options.baseline)
-        return
+    elif options.baseline is not None:
+        try:
+            options.baseline = eval(
+                options.baseline,
+                {"__builtins__": {}},
+                _baseline_namespace(),
+            )
+        except Exception as err:
+            print(err)
+            print("Could not create baseline '%s'. Exiting." % options.baseline)
+            return
 
     filename = args[0]
 

--- a/src/diffpy/srmise/applications/extract.py
+++ b/src/diffpy/srmise/applications/extract.py
@@ -18,6 +18,63 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
+def _resolve_cli_expression(expression, namespace):
+    """Resolve a CLI expression against an explicit namespace.
+
+    Parameters
+    ----------
+    expression : str
+        The user-supplied CLI expression.
+    namespace : dict
+        The explicit namespace allowed during evaluation.
+
+    Returns
+    -------
+    object
+        The resolved class or instance.
+    """
+    return eval(expression, {"__builtins__": {}}, namespace)
+
+
+def _baseline_namespace():
+    """Return the baseline classes supported by the CLI."""
+    from diffpy.srmise.baselines.arbitrary import Arbitrary
+    from diffpy.srmise.baselines.fromsequence import FromSequence
+    from diffpy.srmise.baselines.nanospherical import NanoSpherical
+    from diffpy.srmise.baselines.polynomial import Polynomial
+
+    return {
+        "Arbitrary": Arbitrary,
+        "FromSequence": FromSequence,
+        "NanoSpherical": NanoSpherical,
+        "Polynomial": Polynomial,
+    }
+
+
+def _peakfunction_namespace():
+    """Return the peak-function classes supported by the CLI."""
+    from diffpy.srmise.peaks.gaussian import Gaussian
+    from diffpy.srmise.peaks.gaussianoverr import GaussianOverR
+    from diffpy.srmise.peaks.terminationripples import TerminationRipples
+
+    return {
+        "Gaussian": Gaussian,
+        "GaussianOverR": GaussianOverR,
+        "TerminationRipples": TerminationRipples,
+    }
+
+
+def _modelevaluator_namespace():
+    """Return the model evaluators supported by the CLI."""
+    from diffpy.srmise.modelevaluators.aic import AIC
+    from diffpy.srmise.modelevaluators.aicc import AICc
+
+    return {
+        "AIC": AIC,
+        "AICc": AICc,
+    }
+
+
 def main():
     """Default SrMise entry-point."""
 
@@ -433,7 +490,10 @@ def main():
 
     if options.peakfunction:
         try:
-            options.peakfunction = eval("peaks." + options.peakfunction)
+            options.peakfunction = _resolve_cli_expression(
+                options.peakfunction,
+                _peakfunction_namespace(),
+            )
         except Exception as err:
             print(err)
             print("Could not create peak function '%s'. Exiting." % options.peakfunction)
@@ -441,7 +501,10 @@ def main():
 
     if options.modelevaluator:
         try:
-            options.modelevaluator = eval("modelevaluators." + options.modelevaluator)
+            options.modelevaluator = _resolve_cli_expression(
+                options.modelevaluator,
+                _modelevaluator_namespace(),
+            )
         except Exception as err:
             print(err)
             print("Could not find ModelEvaluator '%s'. Exiting." % options.modelevaluator)
@@ -483,10 +546,12 @@ def main():
 
         bl = NanoSpherical()
         options.baseline = parsepars(bl, options.bspherical)
-
+    elif options.baseline:
         try:
-            options.baseline = eval("baselines." + options.baseline)
-
+            options.baseline = _resolve_cli_expression(
+                options.baseline,
+                _baseline_namespace(),
+            )
         except Exception as err:
             print(err)
             print("Could not create baseline '%s'. Exiting." % options.baseline)

--- a/src/diffpy/srmise/dataclusters.py
+++ b/src/diffpy/srmise/dataclusters.py
@@ -221,7 +221,7 @@ class DataClusters:
                 self.lastcluster_idx = nearest_cluster[0] + 1
             self.clusters = np.insert(
                 self.clusters,
-                int(self.lastcluster_idx),
+                self.lastcluster_idx,
                 [test_idx, test_idx],
                 0,
             )
@@ -304,8 +304,8 @@ class DataClusters:
         # Calculate which of the two nearest clusters is closer
         distances = np.array(
             [
-                self.x[idx] - self.x[self.clusters[int(near_idx) - 1, 1]],
-                self.x[idx] - self.x[self.clusters[int(near_idx), 0]],
+                self.x[idx] - self.x[self.clusters[near_idx - 1, 1]],
+                self.x[idx] - self.x[self.clusters[near_idx, 0]],
             ]
         )
         if distances[0] < np.abs(distances[1]):

--- a/src/diffpy/srmise/dataclusters.py
+++ b/src/diffpy/srmise/dataclusters.py
@@ -206,19 +206,19 @@ class DataClusters:
 
         if np.abs(nearest_cluster[1]) <= self.res:
             # Add to an existing cluster
-            self.lastcluster_idx = nearest_cluster[0]
-            if test_idx < self.clusters[nearest_cluster[0], 0]:
-                self.clusters[nearest_cluster[0], 0] = test_idx
+            self.lastcluster_idx = int(nearest_cluster[0])
+            if test_idx < self.clusters[int(nearest_cluster[0]), 0]:
+                self.clusters[int(nearest_cluster[0]), 0] = test_idx
             else:
-                self.clusters[nearest_cluster[0], 1] = test_idx
+                self.clusters[int(nearest_cluster[0]), 1] = test_idx
         else:
             # Make a new cluster
             if nearest_cluster[1] < 0:
                 # Insert left of nearest cluster
-                self.lastcluster_idx = nearest_cluster[0]
+                self.lastcluster_idx = int(nearest_cluster[0])
             else:
                 # insert right of nearest cluster
-                self.lastcluster_idx = nearest_cluster[0] + 1
+                self.lastcluster_idx = int(nearest_cluster[0]) + 1
             self.clusters = np.insert(
                 self.clusters,
                 int(self.lastcluster_idx),

--- a/src/diffpy/srmise/dataclusters.py
+++ b/src/diffpy/srmise/dataclusters.py
@@ -206,19 +206,19 @@ class DataClusters:
 
         if np.abs(nearest_cluster[1]) <= self.res:
             # Add to an existing cluster
-            self.lastcluster_idx = int(nearest_cluster[0])
-            if test_idx < self.clusters[int(nearest_cluster[0]), 0]:
-                self.clusters[int(nearest_cluster[0]), 0] = test_idx
+            self.lastcluster_idx = nearest_cluster[0]
+            if test_idx < self.clusters[nearest_cluster[0], 0]:
+                self.clusters[nearest_cluster[0], 0] = test_idx
             else:
-                self.clusters[int(nearest_cluster[0]), 1] = test_idx
+                self.clusters[nearest_cluster[0], 1] = test_idx
         else:
             # Make a new cluster
             if nearest_cluster[1] < 0:
                 # Insert left of nearest cluster
-                self.lastcluster_idx = int(nearest_cluster[0])
+                self.lastcluster_idx = nearest_cluster[0]
             else:
                 # insert right of nearest cluster
-                self.lastcluster_idx = int(nearest_cluster[0]) + 1
+                self.lastcluster_idx = nearest_cluster[0] + 1
             self.clusters = np.insert(
                 self.clusters,
                 int(self.lastcluster_idx),
@@ -289,7 +289,7 @@ class DataClusters:
             return None
 
         flat_idx = clusters_flat.searchsorted(idx)
-        near_idx = flat_idx / 2
+        near_idx = flat_idx // 2
 
         if flat_idx == len(clusters_flat):
             # test_idx is right of the last cluster

--- a/src/diffpy/srmise/modelcluster.py
+++ b/src/diffpy/srmise/modelcluster.py
@@ -1174,7 +1174,7 @@ class ModelCluster(object):
         pos = np.array([p["position"] for p in self.model])
         left_idx = pos.searchsorted(self.r_cluster[0])
         right_idx = pos.searchsorted(self.r_cluster[-1])
-        outside_idx = range(0, left_idx)
+        outside_idx = list(range(0, left_idx))
         outside_idx.extend(range(right_idx, len(self.model)))
         # inside_idx = range(left_idx, right_idx)
 
@@ -1538,8 +1538,8 @@ class ModelCluster(object):
                     # Create model with ith peak removed, and distant peaks effectively fixed
                     lo = max(i - peak_range, 0)
                     hi = min(i + peak_range + 1, len(best_model))
-                    check_models[i] = best_model[lo:i].copy()
-                    check_models[i].extend(best_model[i + 1 : hi].copy())
+                    check_models[i] = type(best_model)(best_model[lo:i]).copy()
+                    check_models[i].extend(type(best_model)(best_model[i + 1: hi]).copy())
                     prune_mc.model = check_models[i]
 
                     msg = [

--- a/src/diffpy/srmise/modelcluster.py
+++ b/src/diffpy/srmise/modelcluster.py
@@ -1539,7 +1539,7 @@ class ModelCluster(object):
                     lo = max(i - peak_range, 0)
                     hi = min(i + peak_range + 1, len(best_model))
                     check_models[i] = best_model[lo:i].copy()
-                    check_models[i].extend(best_model[i + 1: hi].copy())
+                    check_models[i].extend(best_model[i + 1 : hi].copy())
                     prune_mc.model = check_models[i]
 
                     msg = [

--- a/src/diffpy/srmise/modelcluster.py
+++ b/src/diffpy/srmise/modelcluster.py
@@ -1539,7 +1539,7 @@ class ModelCluster(object):
                     lo = max(i - peak_range, 0)
                     hi = min(i + peak_range + 1, len(best_model))
                     check_models[i] = type(best_model)(best_model[lo:i]).copy()
-                    check_models[i].extend(type(best_model)(best_model[i + 1: hi]).copy())
+                    check_models[i].extend(type(best_model)(best_model[i + 1 : hi]).copy())
                     prune_mc.model = check_models[i]
 
                     msg = [

--- a/src/diffpy/srmise/modelcluster.py
+++ b/src/diffpy/srmise/modelcluster.py
@@ -1538,8 +1538,8 @@ class ModelCluster(object):
                     # Create model with ith peak removed, and distant peaks effectively fixed
                     lo = max(i - peak_range, 0)
                     hi = min(i + peak_range + 1, len(best_model))
-                    check_models[i] = type(best_model)(best_model[lo:i]).copy()
-                    check_models[i].extend(type(best_model)(best_model[i + 1 : hi]).copy())
+                    check_models[i] = best_model[lo:i].copy()
+                    check_models[i].extend(best_model[i + 1: hi].copy())
                     prune_mc.model = check_models[i]
 
                     msg = [

--- a/src/diffpy/srmise/modelevaluators/aic.py
+++ b/src/diffpy/srmise/modelevaluators/aic.py
@@ -106,7 +106,7 @@ class AIC(ModelEvaluator):
 
         return 1
 
-    def parpenalty(self, k):
+    def parpenalty(self, k, n=None):
         """Returns the cost for adding k parameters to the current model
         cluster.
 

--- a/src/diffpy/srmise/modelevaluators/aic.py
+++ b/src/diffpy/srmise/modelevaluators/aic.py
@@ -85,7 +85,7 @@ class AIC(ModelEvaluator):
         if self.chisq is None:
             self.chisq = self.chi_squared(fit.value(), fit.y_cluster, fit.error_cluster)
 
-        self.stat = self.chisq + self.parpenalty(k, n)
+        self.stat = self.chisq + self.parpenalty(k)
 
         return self.stat
 
@@ -106,7 +106,7 @@ class AIC(ModelEvaluator):
 
         return 1
 
-    def parpenalty(self, k, n=None):
+    def parpenalty(self, k):
         """Returns the cost for adding k parameters to the current model
         cluster.
 
@@ -169,7 +169,7 @@ class AIC(ModelEvaluator):
             logger.warning("AIC.growth_justified(): too few data to evaluate quality reliably.")
             n = self.minpoints(k_actual)
 
-        penalty = self.parpenalty(k_test, n) - self.parpenalty(k_actual, n)
+        penalty = self.parpenalty(k_test) - self.parpenalty(k_actual)
 
         return penalty < self.chisq
 

--- a/src/diffpy/srmise/modelevaluators/base.py
+++ b/src/diffpy/srmise/modelevaluators/base.py
@@ -76,7 +76,7 @@ class ModelEvaluator:
         assert self.method == other.method  # Comparison between same types required
         assert self.stat is not None and other.stat is not None  # The statistic must already be calculated
 
-        if self.higher_is_better is not None:
+        if self.higher_is_better:
             return self.stat < other.stat
         else:
             return other.stat < self.stat
@@ -87,7 +87,7 @@ class ModelEvaluator:
         assert self.method == other.method  # Comparison between same types required
         assert self.stat is not None and other.stat is not None  # The statistic must already be calculated
 
-        if self.higher_is_better is not None:
+        if self.higher_is_better:
             return self.stat <= other.stat
         else:
             return other.stat <= self.stat
@@ -114,7 +114,7 @@ class ModelEvaluator:
         assert self.method == other.method  # Comparison between same types required
         assert self.stat is not None and other.stat is not None  # The statistic must already be calculated
 
-        if self.higher_is_better is not None:
+        if self.higher_is_better:
             return self.stat > other.stat
         else:
             return other.stat > self.stat
@@ -125,7 +125,7 @@ class ModelEvaluator:
         assert self.method == other.method  # Comparison between same types required
         assert self.stat is not None and other.stat is not None  # The statistic must already be calculated
 
-        if self.higher_is_better is not None:
+        if self.higher_is_better:
             return self.stat >= other.stat
         else:
             return other.stat >= self.stat

--- a/src/diffpy/srmise/modelparts.py
+++ b/src/diffpy/srmise/modelparts.py
@@ -430,8 +430,9 @@ class ModelParts(list):
         if isinstance(index, tuple) and len(index) == 2:
             start, end = index
             return self.__class__(super().__getitem__(slice(start, end)))
-        else:
-            return super().__getitem__(index)
+        if isinstance(index, slice):
+            return self.__class__(super().__getitem__(index))
+        return super().__getitem__(index)
 
     def transform(self, in_format="internal", out_format="internal"):
         """Transforms format of parameters in this modelpart.

--- a/src/diffpy/srmise/pdfpeakextraction.py
+++ b/src/diffpy/srmise/pdfpeakextraction.py
@@ -247,7 +247,7 @@ class PDFPeakExtraction(PeakExtraction):
 
         # Enable "dg" as alias for "effective_dy"
         if "dg" in args and "effective_dy" not in args:
-            nargs.add("effective_dy")
+            nargs.append("effective_dy")
 
         # Set other defaults
         PeakExtraction.defaultvars(self, *nargs)
@@ -1000,7 +1000,7 @@ def find_qmax(r, y, showgraphs=False):
     new_y = resample(r, y, new_r)
     new_dr = (new_r[-1] - r[0]) / (len(new_r) - 1)
 
-    yfft = np.imag(np.fft.fft(new_y))[: len(new_y) / 2]
+    yfft = np.imag(np.fft.fft(new_y))[: len(new_y) // 2]
 
     d_ratio = stdratio(yfft)
 

--- a/src/diffpy/srmise/pdfpeakextraction.py
+++ b/src/diffpy/srmise/pdfpeakextraction.py
@@ -888,9 +888,9 @@ class PDFPeakExtraction(PeakExtraction):
             # Generate parameter labels from the baseline function's parameterdict
             blf = self.extracted.baseline.owner()
             if blf.npars > 0:
-                parlbl = blf.parameterdict.keys()
-                paridx = np.array(blf.parameterdict.values()).argsort()
-                lines.append("# " + " ".join([str(parlbl[i]) for i in paridx]))
+                parlbl = list(blf.parameterdict.keys())
+                paridx = np.array(list(blf.parameterdict.values())).argsort()
+                lines.append("# " + " ".join(str(parlbl[i]) for i in paridx))
                 blpars = " ".join([str(p) for p in self.extracted.baseline.pars])
             else:
                 blpars = "(no parameters)"

--- a/src/diffpy/srmise/peakextraction.py
+++ b/src/diffpy/srmise/peakextraction.py
@@ -905,7 +905,7 @@ class PeakExtraction(object):
                 )
             else:
                 # Update an existing cluster
-                mclusters[step.lastcluster_idx].change_slice(step.cut(step.lastcluster_idx))
+                mclusters[int(step.lastcluster_idx)].change_slice(step.cut(step.lastcluster_idx))
 
             # Find newly adjacent clusters
             adjacent = step.find_adjacent_clusters().ravel()
@@ -969,7 +969,7 @@ class PeakExtraction(object):
                 # near_peaks: array containing the indices of two nearest peaks on either side of border_x
                 # other_peaks: all the other peaks in full_cluster
                 # left_data, right_data: indices defining the extent of the "interpeak range" for x, etc.
-                near_peaks = np.array([], dtype=np.int)
+                near_peaks = np.array([], dtype=np.int64)
 
                 # interpeak range goes from peak to peak of next nearest peaks, although their contributions
                 # to the data are still removed.
@@ -1122,7 +1122,7 @@ class PeakExtraction(object):
                 # near_peaks: array containing the indices of two nearest peaks on either side of border_x
                 # other_peaks: all the other peaks in new_cluster
                 # left_data, right_data: indices defining the extent of the "interpeak range" for x, etc.
-                near_peaks = np.array([], dtype=np.int)
+                near_peaks = np.array([], dtype=np.int64)
 
                 # interpeak range goes from peak to peak of next nearest peaks, although their contributions
                 # to the data are still removed.

--- a/src/diffpy/srmise/peakextraction.py
+++ b/src/diffpy/srmise/peakextraction.py
@@ -905,7 +905,7 @@ class PeakExtraction(object):
                 )
             else:
                 # Update an existing cluster
-                mclusters[int(step.lastcluster_idx)].change_slice(step.cut(step.lastcluster_idx))
+                mclusters[step.lastcluster_idx].change_slice(step.cut(step.lastcluster_idx))
 
             # Find newly adjacent clusters
             adjacent = step.find_adjacent_clusters().ravel()

--- a/src/diffpy/srmise/peaks/gaussian.py
+++ b/src/diffpy/srmise/peaks/gaussian.py
@@ -464,12 +464,12 @@ if __name__ == "__main__":
 
     guesspars = [[2.7, 0.15, 5], [3.7, 0.3, 5]]
     guess_peaks = Peaks([pf.actualize(p, "pwa") for p in guesspars])
-    cluster = ModelCluster(guess_peaks, r, y, err, None, AICc, [pf])
+    cluster = ModelCluster(guess_peaks, None, r, y, err, None, AICc, [pf])
 
     qual1 = cluster.quality()
     print(qual1.stat)
     cluster.fit()
-    yfit = cluster.calc()
+    yfit = cluster.value()
     qual2 = cluster.quality()
     print(qual2.stat)
 

--- a/src/diffpy/srmise/peaks/gaussianoverr.py
+++ b/src/diffpy/srmise/peaks/gaussianoverr.py
@@ -534,7 +534,7 @@ if __name__ == "__main__":
 
     guesspars = [[2.7, 0.15, 5], [3.7, 0.3, 5]]
     guess_peaks = Peaks([pf.actualize(p, "pwa") for p in guesspars])
-    cluster = ModelCluster(guess_peaks, r, y, err, None, AICc, [pf])
+    cluster = ModelCluster(guess_peaks, None, r, y, err, None, AICc, [pf])
 
     qual1 = cluster.quality()
     print(qual1.stat)

--- a/src/diffpy/srmise/peaks/gaussianoverr.py
+++ b/src/diffpy/srmise/peaks/gaussianoverr.py
@@ -539,7 +539,7 @@ if __name__ == "__main__":
     qual1 = cluster.quality()
     print(qual1.stat)
     cluster.fit()
-    yfit = cluster.calc()
+    yfit = cluster.value()
     qual2 = cluster.quality()
     print(qual2.stat)
 

--- a/src/diffpy/srmise/peaks/terminationripples.py
+++ b/src/diffpy/srmise/peaks/terminationripples.py
@@ -416,12 +416,12 @@ if __name__ == "__main__":
 
     guesspars = [[2.7, 0.15, 5], [3.7, 0.3, 5]]
     guess_peaks = Peaks([pf2.actualize(p, "pwa") for p in guesspars])
-    cluster = ModelCluster(guess_peaks, r, y_ripple, err, None, AICc, [pf2])
+    cluster = ModelCluster(guess_peaks, None, r, y_ripple, err, None, AICc, [pf2])
 
     qual1 = cluster.quality()
     print(qual1.stat)
     cluster.fit()
-    yfit = cluster.calc()
+    yfit = cluster.valuebl()
     qual2 = cluster.quality()
     print(qual2.stat)
 

--- a/src/diffpy/srmise/peaks/terminationripples.py
+++ b/src/diffpy/srmise/peaks/terminationripples.py
@@ -316,7 +316,7 @@ class TerminationRipples(PeakFunction):
             # issues is difficult to determine without detailed knowledge
             # of the underlying function.
             dr = (r[-1] - r[0]) / (len(r) - 1)
-            segments = np.ceil(dr / dr_super)
+            segments = int(np.ceil(dr / dr_super))
             dr_segmented = dr / segments
 
             rpart = r[rng]

--- a/src/diffpy/srmise/peaks/terminationripples.py
+++ b/src/diffpy/srmise/peaks/terminationripples.py
@@ -421,7 +421,7 @@ if __name__ == "__main__":
     qual1 = cluster.quality()
     print(qual1.stat)
     cluster.fit()
-    yfit = cluster.valuebl()
+    yfit = cluster.value()
     qual2 = cluster.quality()
     print(qual2.stat)
 


### PR DESCRIPTION
@sbillinge ready to review. Note that there are a lot of `py2` legacy in this package. (My bad, I did not clean it up comprehensively on 2024). Now it would give a plot when I run the command `srmise docs/examples/data/Ag-nyquist-qmax30.gr --plot --range 2 3.5 --baseline "Polynomial(degree=1)"` it would give me the plot below.
Also there are some messages for the fitting process:
```
The input PDF appears to be missing information: The sampling interval of the input PDF (0.10471976036036036) is larger than the Nyquist interval (0.10471975511965977) defined by qmax=30.0.  This information is irretrievable.
2.90030e+00 (2.30611e-03)  2.62623e-01 (5.94556e-03)  9.64654e+00 (2.24194e-01)
-3.87207e-01 (3.80378e-01)  -2.92455e-01 (1.41472e-01)
effective_dy: [0.2765272 0.3758883 0.3993384 0.4062425 0.4092704 0.4108721 0.4118211
 0.4124392 0.4128434 0.4131494 0.4133937 0.4135703 0.41365   0.4140212
 0.4138731 0.4139608 0.4140158 0.4140681 0.4140688 0.4141887 0.4141705
 0.4142069 0.4142    0.4142505 0.4142869 0.414276  0.414235  0.4143683
 0.4143157 0.4142939 0.4143335 0.4143717 0.4143361 0.4143605 0.4143777
 0.414216  0.4145213 0.4143604 0.4143672 0.414408  0.4143034 0.4145074
 0.4143658 0.4144454 0.4143957 0.4144191 0.41442   0.4144247 0.4143801
 0.4144333 0.4144703 0.4144277 0.414347  0.4144955 0.4144083 0.41444
 0.4143993 0.4144537 0.4144685 0.4143536 0.4145365 0.4144362 0.4143902
 0.4144907 0.4144324 0.4143906 0.4144803 0.4144227 0.4143587 0.414509
 0.4144201 0.4144356 0.4144505 0.4144687 0.414469  0.4144434 0.4144111
 0.4145219 0.4143796 0.4144955 0.4144445 0.414446  0.4144502 0.4143988
 0.4145152 0.4144222 0.4144654 0.4144388 0.4144548 0.4144297 0.4144823
 0.4144444 0.4144652 0.4144644 0.4144417 0.4144549 0.4144527 0.4144868
 0.4144561 0.4144608 0.4144841 0.4144248 0.4144966 0.4144239 0.4144633
 0.4144556 0.4144629 0.4144406 0.4144775 0.4144525 0.4144847 0.4144663
 0.4144317 0.4145045 0.4144493 0.414473  0.4144754 0.4144237 0.4144983
 0.4144333 0.414449  0.4144681 0.4144388 0.4144618 0.4144581 0.4144738
 0.4144686 0.4144742 0.4144435 0.414468  0.4144499 0.4144547 0.4144545
 0.4144739 0.4144597 0.4144296 0.4144873 0.4144529 0.4144721 0.4144343
 0.4144819 0.4144488 0.4144636 0.4144588 0.4144802 0.4144567 0.4144705
 0.4144523 0.4144734 0.4144571 0.4144744 0.4144514 0.4144552 0.414459
 0.4144734 0.414468  0.41448   0.4144769 0.4144631 0.4144793 0.414472
 0.4144708 0.4144635 0.4144717 0.4144609 0.4144541 0.4144635 0.4144642
 0.4144741 0.414465  0.4144646 0.4144802 0.4144664 0.4144843 0.4144721
 0.4144568 0.4144656 0.4144651 0.4144719 0.4144805 0.4144722 0.4144764
 0.4144649 0.4144721 0.4144765 0.4144656 0.4144695 0.4144606 0.4144579
 0.4144769 0.4144748 0.4144622 0.4144701 0.4144719 0.4144673 0.4144699
 0.4144735 0.4144827 0.4144778 0.4144763 0.4144695 0.4144653 0.4144726
 0.4144633 0.4144626 0.4144595 0.4144623 0.4144694 0.4144665 0.4144765
 0.4144772 0.4144741 0.4144802 0.4144756 0.4144667 0.4144744 0.414475
 0.4144755 0.4144746 0.4144769 0.4144813 0.4144749 0.4144805 0.4144797
 0.4144777 0.4144789 0.4144813 0.4144795 0.4144831 0.4144789 0.4144732
 0.414472  0.4144689 0.4144738 0.4144672 0.4144618 0.4144653 0.4144676
 0.4144723 0.4144764 0.4144796 0.4144753 0.4144743 0.4144714 0.4144631
 0.4144645 0.4144619 0.4144606 0.4144628 0.4144652 0.4144678 0.4144644
 0.4144702 0.4144717 0.4144741 0.4144759 0.4144742 0.414472  0.414475
 0.414476  0.4144714 0.4144684 0.4144675 0.4144691 0.4144731 0.4144762
 0.4144751 0.4144731 0.4144694 0.4144698 0.4144737 0.4144747 0.4144762
 0.414476  0.4144759 0.4144753 0.4144751 0.4144704 0.4144712 0.4144691
 0.4144694 0.4144679 0.4144692 0.4144697 0.4144709 0.4144724 0.4144726
 0.4144725 0.4144727 0.4144744 0.4144709 0.41447   0.4144686 0.4144733
 0.4144777 0.414476  0.4144723 0.414469  0.414467  0.4144685 0.414471
 0.4144731 0.4144743 0.4144733 0.4144693 0.4144691 0.4144692 0.4144668
 0.4144673 0.414468  0.4144688 0.4144693 0.4144716 0.414471  0.4144728
 0.4144734 0.4144724 0.4144769 0.4144768 0.4144725 0.4144718 0.4144688
 0.4144638 0.4144631 0.4144619 0.4144626 0.4144662 0.4144635 0.4144605
 0.4144651 0.4144694 0.414472  0.4144754 0.4144737]
rng: [2.0, 3.5]
pf: [<diffpy.srmise.peaks.gaussianoverr.GaussianOverR object at 0x109d7e900>]
initial_peaks: 
baseline: [-0.60176135  0.        ]
cres: 0.10471975511965977
error_method: <class 'diffpy.srmise.modelevaluators.aic.AIC'>
qmax: 30.0
supersample: 4.0
nyquist: True
scale: False
Extraction type: extract
--- Extracted ---
Slice: slice(None, 15, None)
Quality: 573.557582474722
Baseline: [-0.60176135  0.        ]
Peaks:
[ 2.89549619  0.54157962 18.57789434]


2.90030e+00 (2.30611e-03)  2.62623e-01 (5.94556e-03)  9.64654e+00 (2.24194e-01)
-3.87207e-01 (3.80378e-01)  -2.92455e-01 (1.41472e-01)
```
<img width="641" height="547" alt="Screenshot 2026-04-07 at 10 14 52 PM" src="https://github.com/user-attachments/assets/2f57c3b4-374b-41ac-93a9-9d82a0986442" />
Closes #5 #147 
